### PR TITLE
Revamp login and dashboard experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
       const PROFILE_KEY = 'userProfile';
       let profileModal = null;
       let profileButton = null;
+      let profileQuickAction = null;
       let profileAvatar = null;
       let closeProfileModal = null;
       let profileForm = null;
@@ -216,6 +217,7 @@
       document.addEventListener('DOMContentLoaded', () => {
         profileModal      = document.getElementById('profileModal');
         profileButton     = document.getElementById('profileButton');
+        profileQuickAction= document.getElementById('dashboardProfileCta');
         profileAvatar     = document.getElementById('profileAvatar');
         closeProfileModal = document.getElementById('closeProfileModal');
         profileForm       = document.getElementById('profileForm');
@@ -264,6 +266,7 @@
         cropperModalEl()?.addEventListener('click', (e)=>{ if (e.target === cropperModalEl()) closeCropper(); });
 
         profileButton?.addEventListener('click', openProfileModal);
+        profileQuickAction?.addEventListener('click', openProfileModal);
         profileAvatar?.addEventListener('click', openProfileModal);
         closeProfileModal?.addEventListener('click', () => {
           profileModal?.classList.add('hidden');
@@ -858,8 +861,8 @@
         }
     </style>
 <style id="page-bg-var">
-:root{ --page-bg:url('https://www.elpais.com.co/resizer/v2/2M3Y5OO375AUBBW5LSEVMROWEQ.jpeg?auth=e2bea65b3d499e96df4e788fea02f2dc7a0516c4ff45e08e5301a06a4f3a9c04&smart=true&quality=75&width=1280&height=720'); }
-html,body{ background:#000 !important; }
+:root{ --page-bg:url('https://images.unsplash.com/photo-1517927033932-b3d18e61fb3a?auto=format&fit=crop&w=2000&q=80'); }
+html,body{ background:#05070f !important; }
 </style>
 <style id="bg-blur-style">
   /* Blur del fondo usando variable CSS para la imagen */
@@ -869,21 +872,19 @@ html,body{ background:#000 !important; }
     content: "";
     position: fixed; /* cubre toda la ventana */
     inset: 0;
-    background-image: var(--page-bg);
+    background-image: linear-gradient(135deg, rgba(2,6,23,0.92), rgba(76,29,149,0.35), rgba(15,23,42,0.9)), var(--page-bg);
     background-size: cover;
     background-position: center;
-    /* Quita transparencia: */
-    background-color: #000; /* fallback sólido */
-    opacity: 1 !important; /* fuerza sin transparencia */
-    filter: blur(2px) saturate(108%);
-    transform: scale(1.02);
+    opacity: 0.9 !important;
+    filter: blur(6px) saturate(1.15) brightness(0.75);
+    transform: scale(1.04);
     z-index: 0;
     pointer-events: none;
   }
   /* Asegura que el contenido quede por encima del fondo borroso */
   body > * { position: relative; z-index: 1; }
   /* Canvas animado: entre el blur y el contenido */
-  body > canvas#devilsCanvas{ position: fixed !important; inset: 0; z-index: 0 !important; pointer-events: none; opacity: 0.04; }
+  body > canvas#devilsCanvas{ position: fixed !important; inset: 0; z-index: 0 !important; pointer-events: none; opacity: 0.05; }
   @media (prefers-reduced-motion: reduce){ body > canvas#devilsCanvas{ display:none !important; } }
 </style>
   <style id="dashboard-bg-override">
@@ -994,6 +995,265 @@ html,body{ background:#000 !important; }
   /* QR modal frame subtle glow */
   #qrModal .rounded-xl{ box-shadow: 0 18px 50px rgba(0,0,0,.45) !important; }
   #qrModal [class*="border-white"]{ box-shadow: 0 0 0 1px rgba(255,255,255,.4) inset; }
+</style>
+<style id="minimal-dashboard-refresh">
+  :root {
+    --dash-max-width: 1120px;
+    --dash-shell-pad: clamp(1rem, 3vw, 2.5rem);
+    --dash-shell-pad-mobile: 1.1rem;
+    --dash-card-bg: rgba(12, 17, 27, 0.78);
+    --dash-card-border: rgba(148, 163, 184, 0.18);
+    --dash-card-shadow: 0 28px 60px rgba(4, 10, 20, 0.35);
+    --dash-text-muted: #94a3b8;
+  }
+  @media (max-width: 640px) {
+    :root { --dash-shell-pad: var(--dash-shell-pad-mobile); }
+  }
+  body.dashboard-mode {
+    background: radial-gradient(circle at 20% 20%, rgba(211,47,47,0.12), transparent 55%),
+                radial-gradient(circle at 80% 0%, rgba(211,47,47,0.18), transparent 50%),
+                #05070f;
+  }
+  body.dashboard-mode::before {
+    background: radial-gradient(circle at 50% -10%, rgba(248,113,113,0.18), transparent 55%) !important;
+  }
+  .dashboard-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    background: rgba(8, 12, 24, 0.88);
+    backdrop-filter: blur(18px);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+    padding: 0.85rem calc(var(--dash-shell-pad));
+  }
+  .dashboard-topbar__inner {
+    max-width: var(--dash-max-width);
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem 1.5rem;
+    flex-wrap: wrap;
+  }
+  .dashboard-topbar__avatar {
+    width: 46px;
+    height: 46px;
+    border-radius: 16px;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    background: linear-gradient(135deg, rgba(211,47,47,0.92), rgba(248,113,113,0.28));
+    border: 1px solid rgba(248,113,113,0.45);
+    color: #fff;
+    box-shadow: 0 12px 28px rgba(211,47,47,0.32);
+    cursor: pointer;
+    overflow: hidden;
+    transition: transform .18s ease, box-shadow .25s ease;
+  }
+  .dashboard-topbar__avatar:hover { transform: translateY(-1px); box-shadow: 0 16px 34px rgba(211,47,47,0.4); }
+  .dashboard-topbar__avatar img { width: 100%; height: 100%; object-fit: cover; }
+  .dashboard-topbar__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 0;
+  }
+  .dashboard-topbar__meta h1 { font-size: clamp(1.05rem, 0.8vw + 1rem, 1.35rem); font-weight: 600; }
+  .dashboard-topbar__meta p { color: var(--dash-text-muted); font-size: 0.8rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .dashboard-topbar__date { color: rgba(148,163,184,0.75); font-size: 0.78rem; }
+  .icon-button {
+    width: 42px;
+    height: 42px;
+    display: grid;
+    place-items: center;
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    transition: transform .15s ease, background .2s ease, border-color .2s ease;
+  }
+  .icon-button:hover, .icon-button:focus-visible {
+    transform: translateY(-1px);
+    background: rgba(211,47,47,0.22);
+    border-color: rgba(248,113,113,0.45);
+    outline: none;
+  }
+  .dashboard-shell {
+    width: min(100%, var(--dash-max-width));
+    margin: 0 auto;
+    padding: clamp(1.5rem, 2vw + 1.1rem, 2.75rem) calc(var(--dash-shell-pad)) clamp(5.5rem, 6vw, 6.5rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 1vw + 1.4rem, 2.5rem);
+  }
+  @media (max-width: 640px) {
+    .dashboard-shell { padding: 1.35rem var(--dash-shell-pad) 4.75rem; }
+  }
+  .section-nav {
+    margin-inline: calc(-1 * var(--dash-shell-pad));
+    padding-inline: var(--dash-shell-pad);
+  }
+  #sectionNav {
+    position: sticky;
+    top: 4.6rem;
+    background: linear-gradient(90deg, rgba(8,12,24,0.92) 0%, rgba(8,12,24,0) 100%);
+    z-index: 20;
+    padding-block: 0.75rem;
+  }
+  #sectionNav .chip {
+    background: rgba(15,23,42,0.55);
+    color: #e2e8f0;
+    border: 1px solid rgba(148,163,184,0.22);
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    font-weight: 600;
+    font-size: 0.78rem;
+    transition: background .2s ease, color .2s ease, border-color .2s ease;
+    backdrop-filter: blur(12px);
+  }
+  #sectionNav .chip:hover { background: rgba(211,47,47,0.18); border-color: rgba(248,113,113,0.38); }
+  #sectionNav .chip.active, #sectionNav .chip:focus-visible {
+    background: rgba(211,47,47,0.28);
+    border-color: rgba(248,113,113,0.55);
+    color: #fff;
+    outline: none;
+  }
+  .dash-section-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.6rem 1rem;
+  }
+  .dash-section-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: clamp(1.1rem, 0.9vw + 1rem, 1.4rem);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+  .dash-section-title i { width: 1.1rem; height: 1.1rem; }
+  .dash-section-sub { color: var(--dash-text-muted); font-size: 0.86rem; }
+  .dash-grid { display: grid; gap: clamp(1rem, 1vw + 0.8rem, 1.75rem); }
+  .dash-grid--summary { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+  .dash-grid--two { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+  .dash-card {
+    position: relative;
+    background: var(--dash-card-bg);
+    border: 1px solid var(--dash-card-border);
+    border-radius: 20px;
+    padding: clamp(1.25rem, 1vw + 1.15rem, 1.9rem);
+    box-shadow: var(--dash-card-shadow);
+    backdrop-filter: blur(22px);
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .dash-card__header { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
+  .dash-card h2, .dash-card .font-medium { color: #f8fafc; }
+  .dash-card p, .dash-card .text-gray-400 { color: var(--dash-text-muted) !important; }
+  .dash-chip {
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(211,47,47,0.18);
+    border: 1px solid rgba(211,47,47,0.35);
+    color: #fecaca;
+    letter-spacing: 0.02em;
+  }
+  .dash-chip.positive { background: rgba(34,197,94,0.16); border-color: rgba(34,197,94,0.35); color: #bbf7d0; }
+  .dash-chip.negative { background: rgba(248,113,113,0.12); border-color: rgba(248,113,113,0.32); color: #fecaca; }
+  .dash-card--wide { gap: 1.25rem; }
+  @media (min-width: 1024px) {
+    .dash-grid--summary .dash-card--wide { grid-column: span 2; }
+  }
+  .sparkline-wrapper { position: relative; width: 100%; }
+  .sparkline { width: 100%; aspect-ratio: 16 / 7; display: block; }
+  .sparkline svg { width: 100%; height: 100%; overflow: visible; }
+  .sparkline line { stroke: rgba(148,163,184,0.25); stroke-width: 1; }
+  .sparkline path.sparkline-area { fill: url(#attendanceGradient); opacity: 0.7; }
+  .sparkline path.sparkline-line { fill: none; stroke: #ef4444; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+  .sparkline circle { fill: #ef4444; stroke: #0b0f19; stroke-width: 2; pointer-events: none; }
+  .sparkline-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.85rem;
+    font-size: 0.85rem;
+    color: var(--dash-text-muted);
+  }
+  .sparkline-summary dt {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.68rem;
+    color: rgba(148,163,184,0.7);
+  }
+  .sparkline-summary dd { font-size: 1rem; color: #f8fafc; font-weight: 600; margin-top: 0.25rem; }
+  .sparkline-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.72rem;
+    color: rgba(148,163,184,0.7);
+  }
+  .sparkline-labels span { display: inline-flex; align-items: center; gap: 0.35rem; }
+  .sparkline-labels span::before { content: ''; width: 6px; height: 6px; border-radius: 999px; background: #ef4444; opacity: 0.7; }
+  .sparkline-labels strong { color: #f8fafc; font-weight: 600; }
+  #promoQuickRow { display: flex; gap: 1rem; overflow-x: auto; padding-bottom: 0.35rem; scroll-snap-type: x mandatory; }
+  #promoQuickRow > * { scroll-snap-align: start; }
+  #promosContainer, #engagementSection { width: 100%; }
+  body.dashboard-mode .bg-gray-900 { background: var(--dash-card-bg) !important; border-color: var(--dash-card-border) !important; }
+  body.dashboard-mode .border-gray-800 { border-color: var(--dash-card-border) !important; }
+  body.dashboard-mode .btn-3d-red,
+  body.dashboard-mode .btn-3d-dark,
+  body.dashboard-mode .card-3d {
+    box-shadow: none !important;
+    transform: none !important;
+  }
+  body.dashboard-mode .btn-3d-red {
+    background: linear-gradient(135deg, rgba(211,47,47,0.9), rgba(211,47,47,0.72)) !important;
+    border: 1px solid rgba(248,113,113,0.45) !important;
+  }
+  body.dashboard-mode .btn-3d-dark {
+    background: rgba(15,23,42,0.75) !important;
+    border: 1px solid rgba(148,163,184,0.25) !important;
+  }
+  body.dashboard-mode .btn-3d-red:hover,
+  body.dashboard-mode .btn-3d-red:active,
+  body.dashboard-mode .btn-3d-dark:hover,
+  body.dashboard-mode .btn-3d-dark:active {
+    filter: none !important;
+  }
+  #toast {
+    background: rgba(15,23,42,0.85) !important;
+    border-color: rgba(148,163,184,0.3) !important;
+    backdrop-filter: blur(16px);
+  }
+  #liveAlerts {
+    right: 1.5rem;
+    top: 1.5rem;
+    max-width: min(100%, 320px);
+  }
+  #liveAlerts > div {
+    backdrop-filter: blur(16px);
+    border-radius: 18px;
+    border: 1px solid rgba(148,163,184,0.22);
+    box-shadow: 0 24px 60px rgba(7,12,20,0.45);
+  }
+  @media (max-width: 768px) {
+    #liveAlerts { left: 50%; right: auto; transform: translateX(-50%); width: min(92vw, 360px); }
+  }
+  body.dashboard-mode footer {
+    border-top: 1px solid rgba(148,163,184,0.12);
+    background: rgba(7,11,20,0.82);
+    backdrop-filter: blur(18px);
+    margin-top: auto;
+    padding: 1.5rem var(--dash-shell-pad);
+    color: rgba(203,213,225,0.78);
+  }
+  body.dashboard-mode footer a { color: inherit; }
+  .no-scrollbar::-webkit-scrollbar { display: none; }
+  .no-scrollbar { scrollbar-width: none; }
 </style>
 </head>
 <!-- Add Tailwind responsive utility classes to main containers and buttons -->
@@ -1110,6 +1370,117 @@ html,body{ background:#000 !important; }
   setTimeout(start, 200); // Espera a que canvas esté en DOM y tamaño correcto
 })();
 </script>
+<script id="attendance-spark">
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('attendanceSpark');
+    if (!container) return;
+    const data = [29850, 31240, 30560, 32780, 33450, 34520];
+    const labels = [
+      'vs Pasto',
+      'vs Envigado',
+      'vs Junior',
+      'vs Millonarios',
+      'vs La Equidad',
+      'vs Junior (Vuelta)'
+    ];
+    const max = Math.max(...data);
+    const min = Math.min(...data);
+    const range = max - min || 1;
+    const width = 340;
+    const height = 140;
+    const pad = { top: 12, right: 12, bottom: 22, left: 12 };
+    const step = data.length > 1 ? (width - pad.left - pad.right) / (data.length - 1) : 0;
+    const points = data.map((value, index) => {
+      const x = pad.left + step * index;
+      const norm = (value - min) / range;
+      const y = pad.top + (1 - norm) * (height - pad.top - pad.bottom);
+      return { x, y, value, label: labels[index] || `Juego ${index + 1}` };
+    });
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('preserveAspectRatio', 'none');
+    svg.setAttribute('aria-hidden', 'true');
+
+    const defs = document.createElementNS(ns, 'defs');
+    const gradient = document.createElementNS(ns, 'linearGradient');
+    gradient.id = 'attendanceGradient';
+    gradient.setAttribute('x1', '0');
+    gradient.setAttribute('y1', '0');
+    gradient.setAttribute('x2', '0');
+    gradient.setAttribute('y2', '1');
+    const stopTop = document.createElementNS(ns, 'stop');
+    stopTop.setAttribute('offset', '0%');
+    stopTop.setAttribute('stop-color', '#dc2626');
+    stopTop.setAttribute('stop-opacity', '0.65');
+    const stopBottom = document.createElementNS(ns, 'stop');
+    stopBottom.setAttribute('offset', '100%');
+    stopBottom.setAttribute('stop-color', '#dc2626');
+    stopBottom.setAttribute('stop-opacity', '0');
+    gradient.append(stopTop, stopBottom);
+    defs.appendChild(gradient);
+    svg.appendChild(defs);
+
+    const baseline = document.createElementNS(ns, 'line');
+    baseline.setAttribute('x1', String(pad.left));
+    baseline.setAttribute('x2', String(width - pad.right));
+    baseline.setAttribute('y1', String(height - pad.bottom));
+    baseline.setAttribute('y2', String(height - pad.bottom));
+    svg.appendChild(baseline);
+
+    const pathLine = points.map((p, idx) => `${idx === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+    const area = document.createElementNS(ns, 'path');
+    area.setAttribute('d', `${pathLine} L ${points[points.length - 1].x} ${height - pad.bottom} L ${points[0].x} ${height - pad.bottom} Z`);
+    area.setAttribute('class', 'sparkline-area');
+    svg.appendChild(area);
+
+    const line = document.createElementNS(ns, 'path');
+    line.setAttribute('d', pathLine);
+    line.setAttribute('class', 'sparkline-line');
+    svg.appendChild(line);
+
+    points.forEach((point) => {
+      const dot = document.createElementNS(ns, 'circle');
+      dot.setAttribute('cx', point.x);
+      dot.setAttribute('cy', point.y);
+      dot.setAttribute('r', '4');
+      dot.setAttribute('data-label', point.label);
+      dot.setAttribute('data-value', String(point.value));
+      svg.appendChild(dot);
+    });
+
+    container.innerHTML = '';
+    container.appendChild(svg);
+    container.setAttribute('role', 'img');
+    container.setAttribute('aria-label', `Asistencia en los últimos ${data.length} partidos. Máxima ${max.toLocaleString('es-CO')} aficionados, mínima ${min.toLocaleString('es-CO')}.`);
+
+    const fmt = (value) => `${value.toLocaleString('es-CO')} hinchas`;
+    const latestEl = document.getElementById('attendanceLatest');
+    const avgEl = document.getElementById('attendanceAverage');
+    const peakEl = document.getElementById('attendancePeak');
+    const lastValue = data[data.length - 1];
+    const avgValue = Math.round(data.reduce((acc, val) => acc + val, 0) / data.length);
+
+    if (latestEl) latestEl.textContent = fmt(lastValue);
+    if (avgEl) avgEl.textContent = fmt(avgValue);
+    if (peakEl) peakEl.textContent = fmt(max);
+
+    const changeEl = document.getElementById('attendanceChange');
+    if (changeEl) {
+      const change = ((lastValue - data[0]) / data[0]) * 100;
+      const formatted = `${change >= 0 ? '+' : '−'}${Math.abs(change).toFixed(1)}%`;
+      changeEl.textContent = formatted;
+      changeEl.classList.toggle('positive', change >= 0);
+      changeEl.classList.toggle('negative', change < 0);
+    }
+
+    const labelsEl = document.getElementById('attendanceSparkLabels');
+    if (labelsEl) {
+      labelsEl.innerHTML = labels.map((label, idx) => `<span><strong>${data[idx].toLocaleString('es-CO')}</strong> ${label}</span>`).join('');
+    }
+  });
+</script>
 <style id="ios-modal-fix">
   /* Prevent iOS Safari toolbar from showing busy image under the modal */
   #iosNfcBackdrop{ background: rgba(0,0,0,.88) !important; }
@@ -1118,83 +1489,186 @@ html,body{ background:#000 !important; }
     #iosNfcModal, #iosNfcBackdrop{ min-height:100dvh; }
   }
 </style>
-<div id="loginSection">
-<main class="flex-grow flex flex-col items-center justify-center p-4 sm:p-6 max-w-md w-full mx-auto backdrop-blur-sm">
-  <div class="w-full bg-america-dark/90 rounded-xl shadow-lg p-4 sm:p-8 border border-gray-800 backdrop-blur-sm">
-    <div class="text-center mb-8">
-      <div class="w-24 h-24 bg-america-red rounded-full flex items-center justify-center mx-auto mb-4 logo-ring">
-        <img alt="Logo América de Cali" class="w-16 h-16 rounded-full" src="https://images.seeklogo.com/logo-png/26/1/america-de-cali-logo-png_seeklogo-262007.png"/>
-      </div>
-      <h1 class="text-2xl font-bold mb-2 text-center">Bienvenido,<br/>acerca tu manilla NFC</h1>
-      <p class="text-gray-300">Acerca tu manilla NFC al lector del teléfono</p>
-    </div>
-    <div class="w-full mb-6" id="nfcSection">
-      <button aria-label="Escanear manilla NFC" class="w-full bg-america-red hover:bg-red-700 text-white font-bold py-4 px-4 rounded-xl nfc-pulse flex items-center justify-center gap-2 transition-all text-base sm:text-lg" id="nfcButton">
-        <i class="w-5 h-5" data-feather="radio"></i>
-        <span>Escanear manilla NFC</span>
-      </button>
-      <p class="hidden text-sm text-red-400 mt-2 text-center" id="nfcUnsupported">
-        Este dispositivo no soporta NFC, usa QR o código
-      </p>
-    </div>
-    <div class="flex items-center mb-6 divider">
-      <div class="flex-grow border-t border-gray-700"></div>
-      <span class="mx-4 text-gray-400">o</span>
-      <div class="flex-grow border-t border-gray-700"></div>
-    </div>
-    <div class="w-full mb-6" id="fallbackSection">
-      <div class="flex flex-col gap-3">
-        <button aria-label="Escanear código QR" class="w-full bg-gray-800 hover:bg-gray-700 text-white font-medium py-3 px-4 rounded-xl flex items-center justify-center gap-2" id="qrButton">
-          <i class="w-4 h-4" data-feather="maximize-2"></i>
-          <span>Escanear código QR</span>
-        </button>
-        <button aria-label="Ingresar código manual" class="w-full bg-gray-800 hover:bg-gray-700 text-white font-medium py-3 px-4 rounded-xl flex items-center justify-center gap-2" id="manualButton">
-          <i class="w-4 h-4" data-feather="keypad"></i>
-          <span>Ingresar código manual</span>
-        </button>
-      </div>
-    </div>
-    <div class="hidden w-full mb-6" id="manualInputSection">
-      <div class="mb-4">
-        <input aria-label="Código de acceso" class="w-full bg-gray-800 border border-gray-700 rounded-xl py-3 px-4 text-white focus:outline-none focus:ring-2 focus:ring-america-red" id="manualCode" placeholder="Ingresa tu código" type="text"/>
-      </div>
-      <button aria-label="Validar código" class="w-full bg-america-red hover:bg-red-700 text-white font-bold py-3 px-4 rounded-xl" id="validateButton">
-        Validar código
-      </button>
-    </div>
-    <div class="bg-gray-900 rounded-xl p-4 sm:p-5 w-full mb-6">
-      <h2 class="font-bold text-lg mb-3 flex items-center gap-2">
-        <i class="w-5 h-5 text-america-red" data-feather="help-circle"></i>
-        ¿Cómo funciona?
-      </h2>
-      <div class="space-y-4">
-        <div class="step">
-          <div class="num"><span class="font-bold">1</span></div>
-          <p class="text-gray-300">Acerca tu manilla NFC al dispositivo</p>
-        </div>
-        <div class="step">
-          <div class="num"><span class="font-bold">2</span></div>
-          <p class="text-gray-300">Espera la confirmación de lectura</p>
-        </div>
-        <div class="step">
-          <div class="num"><span class="font-bold">3</span></div>
-          <p class="text-gray-300">Accede a tu dashboard personalizado</p>
-        </div>
-      </div>
-    </div>
+<div id="loginSection" class="relative isolate min-h-screen overflow-hidden">
+  <div class="absolute inset-0 -z-10">
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(248,113,113,0.22),_transparent_55%)]"></div>
+    <div class="absolute inset-0 bg-[linear-gradient(130deg,_rgba(2,6,23,0.92),_rgba(88,28,135,0.35),_rgba(15,23,42,0.9))]"></div>
+    <div class="absolute inset-0 bg-cover bg-center opacity-40 mix-blend-screen" style="background-image: var(--page-bg);"></div>
+    <div class="absolute inset-y-0 right-0 hidden w-2/3 bg-gradient-to-l from-black/70 to-transparent lg:block"></div>
   </div>
-  <div aria-live="assertive" class="toast fixed bottom-4 left-1/2 transform -translate-x-1/2 hidden bg-gray-800 border border-gray-700 text-white px-4 py-3 rounded-xl shadow-lg max-w-xs" id="toast" role="alert"></div>
-  <!-- Live alerts stack (goles, cambios, anuncios del club) -->
-  <div id="liveAlerts" class="fixed top-4 right-4 z-[120] space-y-2"></div>
-</main>
-<footer class="py-4 text-center text-gray-500 text-sm w-full">
-  <div class="flex justify-center gap-4 mb-2">
-    <a class="hover:text-gray-300" href="#">Términos</a>
-    <a class="hover:text-gray-300" href="#">Privacidad</a>
+  <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-12 sm:px-10 lg:px-16">
+    <div class="grid flex-1 items-center gap-12 py-6 lg:grid-cols-[1.08fr_minmax(0,1fr)] lg:py-12">
+      <aside class="order-2 space-y-10 text-slate-100 lg:order-1">
+        <div class="rounded-3xl border border-white/10 bg-white/10 p-8 shadow-2xl backdrop-blur-2xl">
+          <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+            <i data-feather="zap" class="h-4 w-4"></i>
+            Experiencia premium
+          </span>
+          <h2 class="mt-6 text-4xl font-semibold leading-tight text-white sm:text-[2.6rem]">Tu acceso al Pascual, sin filas ni complicaciones.</h2>
+          <p class="mt-4 text-base text-white/70">Recarga tu manilla, verifica tu QR y disfruta beneficios exclusivos diseñados para la hinchada escarlata.</p>
+          <div class="mt-8 grid gap-4 sm:grid-cols-3">
+            <div class="rounded-2xl border border-white/20 bg-black/30 px-4 py-5 text-white/80 shadow-lg backdrop-blur">
+              <p class="text-xs uppercase tracking-[0.25em] text-white/50">Ingresos hoy</p>
+              <p class="mt-2 text-3xl font-semibold text-white">12.542</p>
+            </div>
+            <div class="rounded-2xl border border-white/20 bg-black/30 px-4 py-5 text-white/80 shadow-lg backdrop-blur">
+              <p class="text-xs uppercase tracking-[0.25em] text-white/50">Recargas activas</p>
+              <p class="mt-2 text-3xl font-semibold text-white">386</p>
+            </div>
+            <div class="rounded-2xl border border-white/20 bg-black/30 px-4 py-5 text-white/80 shadow-lg backdrop-blur">
+              <p class="text-xs uppercase tracking-[0.25em] text-white/50">Socios conectados</p>
+              <p class="mt-2 text-3xl font-semibold text-white">1.204</p>
+            </div>
+          </div>
+          <ul class="mt-6 space-y-3 text-sm text-white/70">
+            <li class="flex gap-3">
+              <span class="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">
+                <i data-feather="check" class="h-3.5 w-3.5"></i>
+              </span>
+              <span>Saldo y puntos actualizados en tiempo real con cada acceso.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">
+                <i data-feather="check" class="h-3.5 w-3.5"></i>
+              </span>
+              <span>Verificación dual QR + NFC con alertas inteligentes.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">
+                <i data-feather="check" class="h-3.5 w-3.5"></i>
+              </span>
+              <span>Beneficios y experiencias curadas para la familia escarlata.</span>
+            </li>
+          </ul>
+          <div class="mt-6 flex flex-wrap gap-2">
+            <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-black/40 px-4 py-1.5 text-xs font-medium uppercase tracking-[0.3em] text-white/70"><i data-feather="shield" class="h-4 w-4"></i>Acceso seguro</span>
+            <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-black/40 px-4 py-1.5 text-xs font-medium uppercase tracking-[0.3em] text-white/70"><i data-feather="star" class="h-4 w-4"></i>Socio Platinum</span>
+            <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-black/40 px-4 py-1.5 text-xs font-medium uppercase tracking-[0.3em] text-white/70"><i data-feather="activity" class="h-4 w-4"></i>Tiempo real</span>
+          </div>
+        </div>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div class="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-xl backdrop-blur-xl">
+            <p class="text-xs uppercase tracking-[0.35em] text-white/60">Próximo partido</p>
+            <div class="mt-4 flex items-center justify-between gap-4">
+              <div>
+                <p class="text-lg font-semibold text-white">América vs Nacional</p>
+                <p class="text-sm text-white/60">Domingo · Pascual Guerrero</p>
+              </div>
+              <div class="rounded-2xl bg-gradient-to-br from-rose-500 to-red-600 px-4 py-3 text-center text-white shadow-lg">
+                <p class="text-xs uppercase tracking-[0.4em] text-white/80">Kick-off</p>
+                <p class="text-lg font-semibold">8:10 PM</p>
+              </div>
+            </div>
+            <div class="mt-5 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/60">
+              <span class="inline-flex items-center gap-2"><i data-feather="map-pin" class="h-4 w-4"></i>Puerta 3</span>
+              <span class="inline-flex items-center gap-2"><i data-feather="smartphone" class="h-4 w-4"></i>NFC listo</span>
+            </div>
+          </div>
+          <div class="rounded-3xl border border-emerald-400/40 bg-gradient-to-br from-emerald-500/10 to-emerald-500/5 p-5 shadow-xl backdrop-blur-xl">
+            <p class="text-xs uppercase tracking-[0.35em] text-emerald-200">Beneficio destacado</p>
+            <h3 class="mt-4 text-xl font-semibold text-white">1 bebida cortesía en tribuna occidental.</h3>
+            <p class="mt-3 text-sm text-emerald-100/80">Escanea tu manilla en los puntos aliados y reclámala antes del minuto 30.</p>
+            <div class="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-emerald-200">
+              <i data-feather="gift" class="h-4 w-4"></i>
+              Disponible hoy
+            </div>
+          </div>
+        </div>
+      </aside>
+      <div class="order-1 w-full max-w-xl lg:order-2 lg:justify-self-end">
+        <div role="main" class="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-2xl backdrop-blur-xl sm:p-8">
+          <div class="space-y-8">
+            <div class="space-y-4 text-center">
+              <div class="relative mx-auto flex h-24 w-24 items-center justify-center rounded-full bg-gradient-to-br from-rose-500 via-red-500 to-red-600 shadow-2xl ring-4 ring-white/10">
+                <img alt="Logo América de Cali" class="h-16 w-16 rounded-full" src="https://images.seeklogo.com/logo-png/26/1/america-de-cali-logo-png_seeklogo-262007.png"/>
+              </div>
+              <p class="text-xs font-semibold uppercase tracking-[0.4em] text-white/50">América pass</p>
+              <h1 class="text-3xl font-semibold leading-tight text-white sm:text-[2rem]">Activa tu acceso inteligente</h1>
+              <p class="text-base text-white/70">Conecta tu manilla NFC al instante o utiliza un código alterno para continuar.</p>
+            </div>
+            <div class="space-y-6">
+              <div class="space-y-3" id="nfcSection">
+                <button aria-label="Escanear manilla NFC" class="flex w-full items-center justify-center gap-3 rounded-2xl bg-gradient-to-r from-rose-500 via-red-500 to-red-600 py-4 text-base font-semibold text-white shadow-lg transition hover:shadow-rose-500/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300 nfc-pulse" id="nfcButton">
+                  <i data-feather="radio" class="h-5 w-5"></i>
+                  <span>Escanear manilla NFC</span>
+                </button>
+                <p class="hidden text-sm text-rose-200/80 text-center" id="nfcUnsupported">
+                  Este dispositivo no soporta NFC, usa QR o código.
+                </p>
+              </div>
+              <div class="flex items-center gap-3 text-white/50">
+                <span class="h-px flex-1 bg-white/15"></span>
+                <span class="text-xs uppercase tracking-[0.35em]">o</span>
+                <span class="h-px flex-1 bg-white/15"></span>
+              </div>
+              <div class="grid gap-3" id="fallbackSection">
+                <button aria-label="Escanear código QR" class="group flex w-full items-center justify-center gap-3 rounded-2xl border border-white/15 bg-white/5 py-3 text-sm font-medium text-white/80 transition hover:border-white/40 hover:text-white" id="qrButton">
+                  <i data-feather="maximize-2" class="h-4 w-4"></i>
+                  <span>Escanear código QR</span>
+                </button>
+                <button aria-label="Ingresar código manual" class="group flex w-full items-center justify-center gap-3 rounded-2xl border border-white/15 bg-white/5 py-3 text-sm font-medium text-white/80 transition hover:border-white/40 hover:text-white" id="manualButton">
+                  <i data-feather="keypad" class="h-4 w-4"></i>
+                  <span>Ingresar código manual</span>
+                </button>
+              </div>
+              <div class="hidden space-y-3" id="manualInputSection">
+                <div>
+                  <label class="text-xs font-medium uppercase tracking-[0.3em] text-white/50" for="manualCode">Código manual</label>
+                  <input aria-label="Código de acceso" class="mt-2 w-full rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/30 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-400/40" id="manualCode" placeholder="Ingresa tu código" type="text"/>
+                </div>
+                <button aria-label="Validar código" class="flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-rose-500 via-red-500 to-red-600 py-3 text-base font-semibold text-white shadow-lg transition hover:shadow-rose-500/40" id="validateButton">
+                  Validar código
+                </button>
+              </div>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-5 text-left text-sm text-white/70 shadow-inner shadow-white/5">
+              <div class="flex items-center gap-2 text-white">
+                <i data-feather="help-circle" class="h-5 w-5 text-rose-300"></i>
+                <h2 class="text-base font-semibold">¿Cómo funciona?</h2>
+              </div>
+              <ol class="mt-4 space-y-3">
+                <li class="flex gap-3">
+                  <span class="flex h-8 w-8 items-center justify-center rounded-xl bg-rose-500/20 text-sm font-semibold text-rose-200">1</span>
+                  <p>Acerca tu manilla NFC al dispositivo y espera la vibración de confirmación.</p>
+                </li>
+                <li class="flex gap-3">
+                  <span class="flex h-8 w-8 items-center justify-center rounded-xl bg-rose-500/20 text-sm font-semibold text-rose-200">2</span>
+                  <p>Verificamos tu identidad y sincronizamos tu saldo y beneficios.</p>
+                </li>
+                <li class="flex gap-3">
+                  <span class="flex h-8 w-8 items-center justify-center rounded-xl bg-rose-500/20 text-sm font-semibold text-rose-200">3</span>
+                  <p>Accede a tu dashboard personalizado con estadísticas en vivo.</p>
+                </li>
+              </ol>
+            </div>
+            <div class="flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-4 text-sm text-white/60">
+              <div class="flex flex-wrap gap-2">
+                <span class="inline-flex items-center gap-1.5 rounded-full border border-white/15 px-3 py-1 text-xs font-medium text-white/60"><i data-feather="wifi" class="h-3.5 w-3.5"></i>Contactless</span>
+                <span class="inline-flex items-center gap-1.5 rounded-full border border-white/15 px-3 py-1 text-xs font-medium text-white/60"><i data-feather="award" class="h-3.5 w-3.5"></i>Socio Elite</span>
+              </div>
+              <button id="profileButton" type="button" class="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white/80 transition hover:border-white/40 hover:text-white">
+                <i data-feather="user" class="h-4 w-4"></i>
+                Personalizar perfil
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <footer class="mt-10 flex flex-col items-center gap-2 border-t border-white/10 pt-6 text-xs text-white/60 sm:flex-row sm:justify-between sm:text-sm">
+      <div class="flex flex-wrap justify-center gap-x-6 gap-y-1">
+        <a class="transition hover:text-white" href="#">Términos</a>
+        <a class="transition hover:text-white" href="#">Privacidad</a>
+        <a class="transition hover:text-white" href="#">Soporte</a>
+      </div>
+      <p>© 2024 América de Cali · Manilla NFC</p>
+    </footer>
   </div>
-  <p>© 2024 América de Cali - Manilla NFC</p>
-</footer>
 </div>
+
+<div aria-live="assertive" class="toast pointer-events-auto fixed inset-x-4 bottom-6 z-[140] hidden rounded-2xl border border-white/15 bg-slate-950/90 px-5 py-3 text-sm font-medium text-white shadow-2xl backdrop-blur-xl sm:inset-x-auto sm:left-1/2 sm:-translate-x-1/2 sm:px-6 sm:py-3.5" id="toast" role="alert"></div>
+<!-- Live alerts stack (goles, cambios, anuncios del club) -->
+<div id="liveAlerts" class="pointer-events-none fixed right-4 top-6 z-[130] flex w-full max-w-sm flex-col gap-3 sm:right-10"></div>
 
   <!-- QR Scanner Modal (standalone, before scripts) -->
   <div id="qrModal" class="fixed inset-0 z-[60] hidden items-center justify-center bg-black/60 p-4">
@@ -1934,27 +2408,27 @@ html,body{ background:#000 !important; }
 
   <div id="dashboardSection" class="hidden">
     <div class="bg-america-dark text-white min-h-screen">
-      <header class="bg-black py-4 px-6 sticky top-0 z-10">
-        <div class="flex justify-between items-center max-w-6xl mx-auto">
-          <div class="flex items-center gap-3">
-            <div id="profileAvatar" class="w-10 h-10 bg-america-red rounded-full flex items-center justify-center cursor-pointer">
+      <header class="dashboard-topbar">
+        <div class="dashboard-topbar__inner">
+          <div class="flex items-center gap-3 min-w-0">
+            <div id="profileAvatar" class="dashboard-topbar__avatar">
               <span id="profileInitial" class="font-bold">V</span>
               <img id="profileAvatarImg" class="w-full h-full object-cover hidden rounded-full" src="" alt="Profile">
             </div>
-            <div>
+            <div class="dashboard-topbar__meta">
               <h1 id="profileGreeting" class="font-bold">Hola, Valentina</h1>
-              <p id="profileMeta" class="text-[11px] text-gray-400"></p>
-              <p class="text-xs text-gray-400">Hoy es <span id="currentDate"></span> • <span id="currentTime"></span></p>
+              <p id="profileMeta" class="truncate"></p>
+              <small class="dashboard-topbar__date text-xs text-gray-400">Hoy es <span id="currentDate"></span> • <span id="currentTime"></span></small>
             </div>
           </div>
           <div class="flex items-center gap-2">
-            <button id="openMainMenu" class="p-2 rounded-lg hover:bg-gray-800" aria-label="Menú"><i data-feather="menu" class="w-6 h-6"></i></button>
+            <button id="openMainMenu" class="icon-button" aria-label="Menú"><i data-feather="menu" class="w-5 h-5"></i></button>
           </div>
         </div>
       </header>
 
-      <main class="pb-20 max-w-6xl mx-auto px-4">
-        <section id="sectionNav" class="-mx-4 px-4 py-2">
+      <main class="dashboard-shell">
+         <section id="sectionNav" class="section-nav">
           <div class="flex gap-2 overflow-x-auto no-scrollbar">
             <button class="chip px-3 py-1.5 rounded-lg text-sm" data-section="#secResumen">Resumen</button>
             <button class="chip px-3 py-1.5 rounded-lg text-sm" data-section="#secPromos">Promos</button>
@@ -1963,42 +2437,140 @@ html,body{ background:#000 !important; }
             <button class="chip px-3 py-1.5 rounded-lg text-sm" data-section="#secActividad">Actividad</button>
           </div>
         </section>
-        
+
+        <section class="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,0.85fr)]" data-aos="fade-up">
+          <div class="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-2xl backdrop-blur-xl lg:p-8">
+            <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+                  <i data-feather="flag" class="h-4 w-4"></i>
+                  Próximo encuentro
+                </span>
+                <h2 class="mt-4 text-2xl font-semibold text-white sm:text-[2rem]">América vs Atlético Nacional</h2>
+                <p class="mt-2 text-sm text-white/70">Pascual Guerrero · Domingo 8:10 PM</p>
+              </div>
+              <div class="flex items-center gap-4 rounded-2xl border border-white/15 bg-black/40 px-5 py-4 text-white shadow-xl">
+                <div>
+                  <p class="text-xs uppercase tracking-[0.35em] text-white/50">Puerta asignada</p>
+                  <p class="text-lg font-semibold text-white">Occidental 3</p>
+                </div>
+                <div class="h-12 w-px bg-white/10"></div>
+                <div>
+                  <p class="text-xs uppercase tracking-[0.35em] text-white/50">Butaca</p>
+                  <p class="text-lg font-semibold text-white">Fila 12 · Silla 18</p>
+                </div>
+              </div>
+            </div>
+            <div class="mt-6 grid gap-4 sm:grid-cols-3">
+              <div class="rounded-2xl border border-white/15 bg-black/35 p-4 text-white/70">
+                <p class="text-xs uppercase tracking-[0.3em] text-white/50">Check-in</p>
+                <p class="mt-2 text-xl font-semibold text-white">19:05</p>
+                <p class="text-xs text-white/40">Recomendado</p>
+              </div>
+              <div class="rounded-2xl border border-white/15 bg-black/35 p-4 text-white/70">
+                <p class="text-xs uppercase tracking-[0.3em] text-white/50">Compañía</p>
+                <p class="mt-2 text-xl font-semibold text-white">+3 invitados</p>
+                <p class="text-xs text-white/40">Familia Escarlata</p>
+              </div>
+              <div class="rounded-2xl border border-white/15 bg-black/35 p-4 text-white/70">
+                <p class="text-xs uppercase tracking-[0.3em] text-white/50">Beneficio</p>
+                <p class="mt-2 text-xl font-semibold text-white">2x1 bebidas</p>
+                <p class="text-xs text-white/40">Hasta minuto 30</p>
+              </div>
+            </div>
+          </div>
+          <div class="flex flex-col gap-4 lg:gap-6">
+            <div class="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-xl backdrop-blur-xl">
+              <div class="flex items-center justify-between gap-4">
+                <div>
+                  <p class="text-xs uppercase tracking-[0.35em] text-white/60">Pulso del estadio</p>
+                  <p class="mt-2 text-lg font-semibold text-white">Ambiente al 92%</p>
+                  <p class="text-xs text-white/60">Más vibrante que el último partido</p>
+                </div>
+                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-rose-500 to-red-600 text-2xl font-semibold text-white shadow-lg">92%</div>
+              </div>
+            </div>
+            <div class="grid gap-3 sm:grid-cols-2">
+              <button id="navTopUpBtn" type="button" class="flex items-center justify-between gap-3 rounded-2xl border border-white/20 bg-gradient-to-r from-rose-500 via-red-500 to-red-600 px-5 py-4 text-left text-white shadow-lg transition hover:shadow-rose-500/40">
+                <span>
+                  <span class="block text-xs uppercase tracking-[0.35em] text-white/80">Recarga rápida</span>
+                  <span class="mt-1 block text-lg font-semibold">Agregar saldo</span>
+                </span>
+                <i data-feather="arrow-up-right" class="h-5 w-5"></i>
+              </button>
+              <button id="dashboardProfileCta" type="button" class="flex items-center justify-between gap-3 rounded-2xl border border-white/20 bg-white/5 px-5 py-4 text-left text-white/80 transition hover:border-white/40 hover:text-white">
+                <span>
+                  <span class="block text-xs uppercase tracking-[0.35em]">Personaliza</span>
+                  <span class="mt-1 block text-lg font-semibold text-white">Actualizar perfil</span>
+                </span>
+                <i data-feather="settings" class="h-5 w-5"></i>
+              </button>
+            </div>
+          </div>
+        </section>
+
         <div id="secResumen" class="dash-anchor"></div>
-        <header class="flex items-end justify-between mt-4">
+        <header class="dash-section-header mt-4">
           <h2 class="dash-section-title"><i data-feather="activity" class="w-4 h-4 text-america-red"></i> Tu resumen</h2>
           <span class="dash-section-sub">Puntos, saldo y álbum</span>
         </header>
-        <section id="summaryGrid" class="grid grid-cols-1 md:grid-cols-3 gap-4 my-4">
-          <div class="bg-gray-900 rounded-xl p-5" data-aos="fade-up">
+        <section id="summaryGrid" class="dash-grid dash-grid--summary my-6">
+          <div class="dash-card bg-gray-900 rounded-xl p-5" data-aos="fade-up">
             <div class="flex items-center justify-between mb-2">
-              <h2 class="text-gray-400 font-medium">Tus puntos</h2>
+              <h2 class="text-sm text-gray-400 font-medium">Tus puntos</h2>
               <i data-feather="award" class="text-america-red"></i>
             </div>
             <p class="text-3xl font-bold" id="pointsValue" data-amount="1850">1,850</p>
             <p class="text-sm text-gray-400 mt-1">Nivel: Familia Escarlata</p>
           </div>
-          <div class="bg-gray-900 rounded-xl p-5" data-aos="fade-up" data-aos-delay="100">
+          <div class="dash-card bg-gray-900 rounded-xl p-5" data-aos="fade-up" data-aos-delay="100">
             <div class="flex items-center justify-between mb-2">
-              <h2 class="text-gray-400 font-medium">Saldo disponible</h2>
+              <h2 class="text-sm text-gray-400 font-medium">Saldo disponible</h2>
               <i data-feather="dollar-sign" class="text-america-red"></i>
             </div>
             <p class="text-3xl font-bold" id="balanceAmount" data-amount="42500">$42,500</p>
             <p class="text-sm text-gray-400 mt-1">COP</p>
           </div>
-          <div class="bg-gray-900 rounded-xl p-5" data-aos="fade-up" data-aos-delay="200">
+          <div class="dash-card bg-gray-900 rounded-xl p-5" data-aos="fade-up" data-aos-delay="200">
             <div class="flex items-center justify-between mb-2">
-              <h2 class="text-gray-400 font-medium">Álbum Escarlata</h2>
+              <h2 class="text-sm text-gray-400 font-medium">Álbum Escarlata</h2>
               <i data-feather="image" class="text-america-red"></i>
             </div>
             <p id="albumProgressLabel" class="text-xl font-bold">137/200</p>
             <div class="progress-bar mt-2"><div id="albumProgressBarFill" class="progress-fill" style="width:68.5%"></div></div>
             <button class="mt-3 text-sm bg-america-red hover:bg-red-700 py-1 px-3 rounded-lg">Canjear lámina</button>
           </div>
+          <div class="dash-card bg-gray-900 rounded-xl p-5 dash-card--wide" data-aos="fade-up" data-aos-delay="300">
+            <div class="dash-card__header">
+              <div>
+                <h2 class="text-gray-200 font-semibold text-base">Asistencia del Pascual</h2>
+                <p class="text-sm text-gray-400">Últimos 6 partidos como local</p>
+              </div>
+              <span id="attendanceChange" class="dash-chip">0%</span>
+            </div>
+            <div class="sparkline-wrapper">
+              <div id="attendanceSpark" class="sparkline"></div>
+            </div>
+            <dl class="sparkline-summary">
+              <div>
+                <dt>Último juego</dt>
+                <dd id="attendanceLatest">--</dd>
+              </div>
+              <div>
+                <dt>Promedio</dt>
+                <dd id="attendanceAverage">--</dd>
+              </div>
+              <div>
+                <dt>Máximo</dt>
+                <dd id="attendancePeak">--</dd>
+              </div>
+            </dl>
+            <div class="sparkline-labels" id="attendanceSparkLabels"></div>
+          </div>
         </section>
 
         <div id="secPromos" class="dash-anchor"></div>
-        <header class="flex items-end justify-between mt-8">
+        <header class="dash-section-header mt-8">
           <h2 class="dash-section-title"><i data-feather="gift" class="w-4 h-4 text-america-red"></i> Promociones y Experiencias</h2>
           <span class="dash-section-sub">Ofertas dinámicas y canjes</span>
         </header>
@@ -2010,17 +2582,17 @@ html,body{ background:#000 !important; }
           </div>
           <!-- Cupones rápidos para no dejar vacío el bloque cuando hay pocas promos -->
           <div id="promoQuickRow" class="flex gap-2 overflow-x-auto no-scrollbar mb-3"></div>
-          <div id="promosContainer" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
+          <div id="promosContainer" class="dash-grid dash-grid--two"></div>
         </section>
 
         <div id="secComunidad" class="dash-anchor"></div>
-        <header class="flex items-end justify-between mt-8">
+        <header class="dash-section-header mt-8">
           <h2 class="dash-section-title"><i data-feather="users" class="w-4 h-4 text-america-red"></i> Retos y Comunidad</h2>
           <span class="dash-section-sub">Reto diario y compartir</span>
         </header>
-        <section id="engagementSection" class="grid grid-cols-1 md:grid-cols-2 gap-4 my-4" data-aos="fade-up">
+        <section id="engagementSection" class="dash-grid dash-grid--two my-4" data-aos="fade-up">
           <!-- Reto diario -->
-          <div class="bg-gray-900 rounded-xl p-5 border border-gray-800">
+          <div class="dash-card bg-gray-900 rounded-xl p-5 border border-gray-800">
             <div class="flex items-center justify-between mb-2">
               <h2 class="text-gray-400 font-medium">Reto diario</h2>
               <span id="dailyChallengeStatus" class="text-xs px-2 py-1 rounded bg-gray-800 text-gray-300">Pendiente</span>
@@ -2029,7 +2601,7 @@ html,body{ background:#000 !important; }
             <button id="openDailyChallengeBtn" class="mt-3 text-sm bg-america-red hover:bg-red-700 py-2 px-3 rounded-lg flex items-center gap-2"><i data-feather="zap" class="w-4 h-4"></i>Jugar ahora</button>
           </div>
           <!-- Comparte y gana -->
-          <div class="bg-gray-900 rounded-xl p-5 border border-gray-800">
+          <div class="dash-card bg-gray-900 rounded-xl p-5 border border-gray-800">
             <div class="flex items-center justify-between mb-2">
               <h2 class="text-gray-400 font-medium">Comparte y gana</h2>
               <span class="text-xs px-2 py-1 rounded bg-gray-800 text-gray-300">#AmericaDeCali</span>
@@ -2059,20 +2631,26 @@ html,body{ background:#000 !important; }
         </script>
 
         <section class="my-8" data-aos="fade-up">
-          <div class="flex justify-between items-center mb-4">
-            <h2 class="text-xl font-bold">Recomendaciones para ti</h2>
+          <div class="dash-section-header mb-4">
+            <h2 class="dash-section-title"><i data-feather="target" class="w-4 h-4 text-america-red"></i> Recomendaciones para ti</h2>
             <button class="text-sm text-gray-400 hover:text-white">Ver más</button>
           </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div class="bg-gray-900 rounded-xl p-5">
-              <div class="flex justify-between">
-                <div><h3 class="font-medium mb-1">Combo Familiar Entretiempo</h3><p class="text-sm text-gray-400">-15% de descuento</p></div>
+          <div class="dash-grid dash-grid--two">
+            <div class="dash-card bg-gray-900 rounded-xl p-5">
+              <div class="flex justify-between gap-4">
+                <div>
+                  <h3 class="font-medium mb-1 text-white">Combo Familiar Entretiempo</h3>
+                  <p class="text-sm text-gray-400">-15% de descuento</p>
+                </div>
                 <button id="redeemComboBtn" class="self-start bg-america-red hover:bg-red-700 text-white py-1 px-3 rounded-lg text-sm">Canjear</button>
               </div>
             </div>
-            <div class="bg-gray-900 rounded-xl p-5">
-              <div class="flex justify-between">
-                <div><h3 class="font-medium mb-1">Trivia Histórica</h3><p class="text-sm text-gray-400">+50 pts por participar</p></div>
+            <div class="dash-card bg-gray-900 rounded-xl p-5">
+              <div class="flex justify-between gap-4">
+                <div>
+                  <h3 class="font-medium mb-1 text-white">Trivia Histórica</h3>
+                  <p class="text-sm text-gray-400">+50 pts por participar</p>
+                </div>
                 <button id="playTriviaBtn" class="self-start bg-america-red hover:bg-red-700 text-white py-1 px-3 rounded-lg text-sm" type="button">Jugar</button>
               </div>
             </div>
@@ -2557,6 +3135,7 @@ html,body{ background:#000 !important; }
           const modal = document.getElementById('qrModal');
           modal.classList.add('hidden');
           modal.classList.remove('flex');
+          qrPurpose = 'login';
         }
 
         async function startQrScanner(){
@@ -2687,6 +3266,7 @@ html,body{ background:#000 !important; }
 
         // Abrir modal y comenzar a escanear
         document.getElementById('qrButton').addEventListener('click', () => {
+          qrPurpose = 'login';
           openQrModal();
           startQrScanner();
         });
@@ -2758,6 +3338,7 @@ html,body{ background:#000 !important; }
           if (!topUpModal) return;
           topUpModal.classList.add('hidden');
           topUpModal.classList.remove('flex');
+          qrPurpose = 'login';
         }
         navTopUpBtn?.addEventListener('click', openTopUp);
         closeTopUpBtn?.addEventListener('click', closeTopUp);
@@ -2834,8 +3415,10 @@ html,body{ background:#000 !important; }
           modal.classList.add('hidden');
           modal.classList.remove('flex');
           document.getElementById('verifyCodeSection').classList.add('hidden');
+          qrPurpose = 'login';
         }
         function verificationSuccess() {
+          qrPurpose = 'login';
           closeVerification();
           processTopUp();
         }
@@ -2897,24 +3480,29 @@ html,body{ background:#000 !important; }
         });
         document.getElementById('closeVerification').addEventListener('click', closeVerification);
 
-        function showToast(message, type) {
-            const toast = document.getElementById('toast');
-            toast.textContent = message;
-            toast.classList.remove('hidden');
-            
-            // Set color based on type
-            if (type === 'success') {
-                toast.classList.add('bg-green-800', 'border-green-700');
-            } else if (type === 'error') {
-                toast.classList.add('bg-red-800', 'border-red-700');
-            } else if (type === 'info') {
-                toast.classList.add('bg-blue-800', 'border-blue-700');
-            }
-            
-            setTimeout(() => {
-                toast.classList.add('hidden');
-                toast.classList.remove('bg-green-800', 'border-green-700', 'bg-red-800', 'border-red-700', 'bg-blue-800', 'border-blue-700');
-            }, 3000);
+        let toastTimer = null;
+        function showToast(message, type = 'info') {
+          const toast = document.getElementById('toast');
+          if (!toast) return;
+          const toneClasses = {
+            success: ['bg-emerald-500/15', 'border-emerald-300/50', 'text-emerald-100'],
+            error: ['bg-rose-500/15', 'border-rose-300/50', 'text-rose-100'],
+            info: ['bg-sky-500/15', 'border-sky-300/50', 'text-sky-100']
+          };
+          const palette = Object.values(toneClasses).flat();
+
+          toast.classList.remove(...palette);
+          toast.textContent = message;
+          toast.classList.remove('hidden');
+
+          const selection = toneClasses[type] || toneClasses.info;
+          toast.classList.add(...selection);
+
+          if (toastTimer) window.clearTimeout(toastTimer);
+          toastTimer = window.setTimeout(() => {
+            toast.classList.add('hidden');
+            toast.classList.remove(...palette);
+          }, 3200);
         }
 
         // ---- Global overlay helpers ----
@@ -3051,7 +3639,6 @@ html,body{ background:#000 !important; }
     setInterval(updateDateTime, 1000);
   });
 </script>
-    </script>
 
 <div id="iosNfcModal" class="fixed inset-0 z-[80] hidden">
   <!-- backdrop -->


### PR DESCRIPTION
## Summary
- redesign the login experience into a premium two-column hero with glass cards, responsive CTAs, and refined palette
- add a dashboard welcome hero highlighting the next match, quick stats, and one-tap actions for recarga and perfil management
- tighten toast styling and QR flow state handling so notifications render correctly and the scanner always returns to login mode after top-ups

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db6725b72883318431b47e99577a73